### PR TITLE
8 not found page 404

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { HomePage, ProfilePage, FeupExchangePage, TimeTableSchedulerPage } from './pages'
 import './app.css'
 import FeupExchangeFaqs from './pages/FeupExchangeFaqs'
+import NotFoundPage from './pages/NotFound'
 
 const pages = [
   { path: '/about', location: 'About', element: HomePage, liquid: true },
@@ -10,6 +11,7 @@ const pages = [
   { path: '/planner', location: 'Planner', element: TimeTableSchedulerPage, liquid: true },
   { path: '/exchange', location: 'Exchange', element: FeupExchangePage, liquid: true },
   { path: '/faqs', location: 'FAQs', element: FeupExchangeFaqs, liquid: true },
+  { path: '/*', location: 'NotFound', element: NotFoundPage, liquid: true }, 
 ]
 
 const redirects = [

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -9,11 +9,9 @@ const NotFoundPage = () => (
             <Link to="/" className="flex h-auto w-fit items-center justify-center rounded border-2 border-primary bg-primary px-3 py-2 text-xs font-medium text-white transition hover:opacity-80 lg:text-sm xl:px-4">
                 Go to Planner
             </Link>
-        {/* <img className="max-w-lg rounded shadow" src={image} alt="card" /> */}
         </div>
         {/* Mobile */}
         <div className="flex flex-col items-center justify-between space-y-4 py-8 md:hidden">
-        {/* <img className="w-full rounded shadow" src={image} alt="card" /> */}
             <h1 className="text-4xl text-center font-semibold">404</h1>
             <h2 className="text-3xl mb-2 text-center font-medium">PAGE NOT FOUND</h2>
             <Link to="/" className="flex h-auto w-fit items-center justify-center rounded border-2 border-primary bg-primary px-3 py-2 text-xs font-medium text-white transition hover:opacity-80 lg:text-sm xl:px-4">

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,0 +1,7 @@
+const NotFoundPage = () => (
+    <div>
+      Page Not Found
+    </div>
+  )
+  
+  export default NotFoundPage

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,7 +1,26 @@
+import { Link } from "react-router-dom"
+
 const NotFoundPage = () => (
-    <div>
-      Page Not Found
-    </div>
+    <>
+        {/* Desktop */}
+        <div className="hidden flex flex-col items-center justify-between space-y-4 py-8 md:flex">
+            <h1 className="text-4xl text-center font-semibold">404</h1>
+            <h2 className="text-3xl mb-2 text-center font-medium">PAGE NOT FOUND</h2>
+            <Link to="/" className="flex h-auto w-fit items-center justify-center rounded border-2 border-primary bg-primary px-3 py-2 text-xs font-medium text-white transition hover:opacity-80 lg:text-sm xl:px-4">
+                Go to Planner
+            </Link>
+        {/* <img className="max-w-lg rounded shadow" src={image} alt="card" /> */}
+        </div>
+        {/* Mobile */}
+        <div className="flex flex-col items-center justify-between space-y-4 py-8 md:hidden">
+        {/* <img className="w-full rounded shadow" src={image} alt="card" /> */}
+            <h1 className="text-4xl text-center font-semibold">404</h1>
+            <h2 className="text-3xl mb-2 text-center font-medium">PAGE NOT FOUND</h2>
+            <Link to="/" className="flex h-auto w-fit items-center justify-center rounded border-2 border-primary bg-primary px-3 py-2 text-xs font-medium text-white transition hover:opacity-80 lg:text-sm xl:px-4">
+                Go to Planner
+            </Link>
+        </div>
+    </>
   )
   
   export default NotFoundPage


### PR DESCRIPTION
The page appears when the address is incorrect, as intended, its design is very simple, however.
The page consists of two lines of text, a bigger one with the text "404" and a smaller with the text "PAGE NOT FOUND", and a button beneath them with the text "Go to Planner" that redirects to the "/" route.
Desktop:
![imagem](https://user-images.githubusercontent.com/75994325/181942387-8ff5e04e-040e-4775-820d-d1f20613ccfb.png)
Mobile:
![imagem](https://user-images.githubusercontent.com/75994325/181943312-cea37d9e-f4b7-4463-9d73-16fa769fd3e9.png)
