### PR TITLE
127-importexport-update-input-box-borders

### DIFF
--- a/src/components/planner/ShareButtons.tsx
+++ b/src/components/planner/ShareButtons.tsx
@@ -336,15 +336,16 @@ const ShareButtons = ({majorHook, schedule, multipleOptionsHook, setIsImportedSc
             <div className="absolute inset-y-0 left-0 col-span-6">
             
             </div>
-            <input placeholder='Insere o link do horário...' id="schedule-input" className="inline-flex w-full items-center justify-center whitespace-nowrap rounded bg-tertiary p-2 
-                        text-center text-sm font-normal text-white transition hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-50" required>
+            <input placeholder='Insere o link do horário...' id="schedule-input" className="inline-flex w-full items-center justify-center whitespace-nowrap rounded bg-white
+                        dark:bg-darkish dark:text-white dark:placeholder:text-white p-2.5 text-center text-sm font-normal text-black transition hover:opacity-80 disabled:cursor-not-allowed 
+                        disabled:opacity-50 border-2 border-gray-300 outline-none focus:border-tertiary dark:focus:border-gray-300 dark:border-tertiary" required>
             </input>
             <button 
                         onClick={() => openDecisionModal()}
 
                         id='ImportButton'
                         title="Importar o link inserido"
-                        className="absolute right-0.5 bottom-0.5 items-center justify-center  whitespace-nowrap rounded bg-tertiary p-2 
+                        className="absolute right-2 bottom-1.5 items-center justify-center  whitespace-nowrap rounded bg-tertiary p-2 
                         text-center text-sm font-normal text-white transition hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-50"
                         >
                         <UploadIcon className="h-4 w-4" />
@@ -356,10 +357,10 @@ const ShareButtons = ({majorHook, schedule, multipleOptionsHook, setIsImportedSc
                     <button
                         onClick={() => copySchedule()}
                         title="Copiar o link do horário"
-                        className="inline-flex w-full items-center justify-center whitespace-nowrap rounded bg-tertiary p-2 
+                        className="inline-flex w-full items-center justify-center whitespace-nowrap rounded bg-tertiary p-2.5
                         text-center text-sm font-normal text-white transition hover:opacity-80 disabled:cursor-not-allowed disabled:opacity-50"
                         >
-                        {icon? <CheckIcon className='w-6 h-5'/> : <DocumentDuplicateIcon className='w-6 h-5' />}
+                        {icon? <CheckIcon className='w-6 h-6'/> : <DocumentDuplicateIcon className='w-6 h-6' />}
                     </button>
 
                 </div>

--- a/src/components/planner/ShareButtons.tsx
+++ b/src/components/planner/ShareButtons.tsx
@@ -336,7 +336,7 @@ const ShareButtons = ({majorHook, schedule, multipleOptionsHook, setIsImportedSc
             <div className="absolute inset-y-0 left-0 col-span-6">
             
             </div>
-            <input placeholder='Insere o link do horário...' id="schedule-input" className="inline-flex w-full items-center justify-center whitespace-nowrap rounded bg-white
+            <input placeholder='Insere o link do horário...' className="inline-flex w-full items-center justify-center whitespace-nowrap rounded bg-white
                         dark:bg-darkish dark:text-white dark:placeholder:text-white p-2.5 text-center text-sm font-normal text-black transition hover:opacity-80 disabled:cursor-not-allowed 
                         disabled:opacity-50 border-2 border-gray-300 outline-none focus:border-tertiary dark:focus:border-gray-300 dark:border-tertiary" required>
             </input>

--- a/src/styles/schedule.css
+++ b/src/styles/schedule.css
@@ -180,8 +180,3 @@
 .no-borders {
   border: 0 !important;
 }
-
-#schedule-input {
-  background-color: white;
-  color: black;
-}


### PR DESCRIPTION
Closes #127 

Added a border to the link's input box, removed the default outline when focusing the input box and changed the DocumentDuplicateIcon size to match the new size of the input box (I can try to keep it with the same size and align its center with the input box's center). I also changed the background of the input box while on dark mode although it wasn't the plan. There are videos below with the design I went for and different variations I tried before reaching the final design. I'd like to know what you like/dislike about what I implemented and if you prefer any of the other options or other combinations.

## What I implemented (option 1)
[implemented.webm](https://user-images.githubusercontent.com/96185733/220778111-d010dc9c-2648-439e-9277-ec2bd548ba5a.webm)

## Option 2 (switched border colors on dark mode)
[option2.webm](https://user-images.githubusercontent.com/96185733/220778482-e2df5ba8-59eb-46b7-a1c5-def5d4300369.webm)

## Option 3
[option3.webm](https://user-images.githubusercontent.com/96185733/220779858-63d60a5c-316d-4bc9-ba24-a9193baaf833.webm)

## Option 4 (doesn't have the default outline removed)
[option4.webm](https://user-images.githubusercontent.com/96185733/220782569-2bc487b5-304d-4183-b5cd-17994164fa9b.webm)

## Option 5
[option5.webm](https://user-images.githubusercontent.com/96185733/220782959-3b4b6f7f-77d5-4071-863c-482e07b3edf2.webm)
