### PR TITLE
Removed tts-bridge on docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,3 @@ services:
     env_file:
       - .env
 
-networks:
-  default:
-    external:
-      name: tts_bridge


### PR DESCRIPTION
While trying to run docker-compose build, i was receiving an error message because there was some troubles with a few lines at docker-compose.yaml. After removing them, everything is fine and i can run docker without giving me any error messages. If  everything seems fine for you, i think it would be better to remove this lines.