### PR TITLE
Feature/professor information

### DIFF
--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -54,6 +54,12 @@ export type Major = {
 //   class_name: string // e.g. 1MIEIC01
 //   composed_class_name: string // e.g. COMP752
 // }
+
+export type ProfessorInformation = {
+  acronym: string
+  name: string
+}
+
 export type CourseSchedule = {
   day: number
   duration: string
@@ -65,8 +71,10 @@ export type CourseSchedule = {
   last_updated: string
   class_name: string // e.g. 1MIEIC01
   composed_class_name: string // e.g. COMP752
-  professor_sigarra_id: string
-  professor_acronyms: Array<string>
+  // professor_sigarra_id: string
+  // professor_acronyms: Array<string>                           // eliminar
+  professors_link: string
+  professor_information: Array<ProfessorInformation>          // new
 }
 
 /* Options */

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -86,8 +86,8 @@ export type CourseOption = {
   course: CheckedCourse
   option: CourseSchedule | null
   schedules: CourseSchedule[]
-  teachers: string[]
-  filteredTeachers: string[]
+  teachers: ProfessorInformation[]
+  filteredTeachers: ProfessorInformation[]
 }
 
 export type Subject = {

--- a/src/api/storage.ts
+++ b/src/api/storage.ts
@@ -2,7 +2,7 @@ import { MultipleOptions } from '../@types'
 import { getCourseTeachers } from '../utils'
 
 
-const INITIAL_VALUE = { index: 0, selected: [], options: [], names: Array.from({ length: 10 }, (_, i) => `Horário ${i + 1}`), teachers: [], filteredTeachers: [] }
+const INITIAL_VALUE = { index: 0, selected: [], options: [], names: Array.from({ length: 10 }, (_, i) => `Horário ${i + 1}`) }
 
 const isStorageValid = (key: string, daysElapsed: number) => {
   const stored = JSON.parse(localStorage.getItem(key))

--- a/src/components/planner/ScheduleListbox.tsx
+++ b/src/components/planner/ScheduleListbox.tsx
@@ -169,7 +169,7 @@ const ScheduleListbox = ({ courseOption, multipleOptionsHook, isImportedSchedule
     courseOption.filteredTeachers = [...selectedTeachers];
     setSelectedTeachers(selectedTeachers)
     if (selectedOption) {
-      setSelectedOption(selectedOption.professor_acronyms.some(element => selectedTeachers.includes(element)) ? selectedOption : null)
+      setSelectedOption(selectedOption.professor_information.some(element => selectedTeachers.includes(element.acronym)) ? selectedOption : null)
       setLastSelected(null)
     }
   })
@@ -182,7 +182,7 @@ const ScheduleListbox = ({ courseOption, multipleOptionsHook, isImportedSchedule
 
     adaptedSchedules.forEach((schedule) => {
     
-      if (schedule === null || schedule.professor_acronyms.some(element => selectedTeachers.includes(element)))
+      if (schedule === null || schedule.professor_information.some(element => selectedTeachers.includes(element.acronym)))
         selectedSchedules.push(schedule);
     })
 

--- a/src/components/planner/schedules/InspectLessonBox.tsx
+++ b/src/components/planner/schedules/InspectLessonBox.tsx
@@ -9,7 +9,7 @@ type Props = {
 
 const InspectLessonBox = ({ lesson, conflict }: Props) => {
   const lessonType = lesson.schedule.lesson_type
-  console.log(lesson.schedule.professors_link)
+  const professorDescription = lesson.schedule.professor_information.map(prof_info => prof_info.name).join('\n')
   return (
     <div
       className={classNames(
@@ -42,7 +42,7 @@ const InspectLessonBox = ({ lesson, conflict }: Props) => {
         <div className="flex w-full items-center justify-between gap-2">
           <span title="Sala">{lesson.schedule.location}</span>
           <a href={lesson.schedule.professors_link} className="cursor-pointer hover:underline">
-            <span title="Professor(es)" className="whitespace-nowrap">
+            <span title={professorDescription} className="whitespace-nowrap">
               {lesson.schedule.professor_information.map(prof_info => prof_info.acronym).join(', ')}
             </span>
           </a>

--- a/src/components/planner/schedules/InspectLessonBox.tsx
+++ b/src/components/planner/schedules/InspectLessonBox.tsx
@@ -41,7 +41,7 @@ const InspectLessonBox = ({ lesson, conflict }: Props) => {
 
         <div className="flex w-full items-center justify-between gap-2">
           <span title="Sala">{lesson.schedule.location}</span>
-          <a href={lesson.schedule.professors_link} className="cursor-pointer hover:underline">
+          <a href={lesson.schedule.professors_link} target="_blank" rel="noreferrer" className="cursor-pointer hover:underline">
             <span title={professorDescription} className="whitespace-nowrap">
               {lesson.schedule.professor_information.map(prof_info => prof_info.acronym).join(', ')}
             </span>

--- a/src/components/planner/schedules/InspectLessonBox.tsx
+++ b/src/components/planner/schedules/InspectLessonBox.tsx
@@ -9,7 +9,7 @@ type Props = {
 
 const InspectLessonBox = ({ lesson, conflict }: Props) => {
   const lessonType = lesson.schedule.lesson_type
-  const professorDescription = lesson.schedule.professor_information.map(prof_info => prof_info.name).join('\n')
+  const professorDescription = lesson.schedule.professor_information.map((prof_info) => prof_info.name).join('\n')
   return (
     <div
       className={classNames(
@@ -41,9 +41,14 @@ const InspectLessonBox = ({ lesson, conflict }: Props) => {
 
         <div className="flex w-full items-center justify-between gap-2">
           <span title="Sala">{lesson.schedule.location}</span>
-          <a href={lesson.schedule.professors_link} target="_blank" rel="noreferrer" className="cursor-pointer hover:underline">
+          <a
+            href={lesson.schedule.professors_link}
+            target="_blank"
+            rel="noreferrer"
+            className="cursor-pointer hover:underline"
+          >
             <span title={professorDescription} className="whitespace-nowrap">
-              {lesson.schedule.professor_information.map(prof_info => prof_info.acronym).join(', ')}
+              {lesson.schedule.professor_information.map((prof_info) => prof_info.acronym).join(', ')}
             </span>
           </a>
         </div>

--- a/src/components/planner/schedules/InspectLessonBox.tsx
+++ b/src/components/planner/schedules/InspectLessonBox.tsx
@@ -41,7 +41,7 @@ const InspectLessonBox = ({ lesson, conflict }: Props) => {
 
         <div className="flex w-full items-center justify-between gap-2">
           <span title="Sala">{lesson.schedule.location}</span>
-          <a href={lesson.schedule.professors_link}>
+          <a href={lesson.schedule.professors_link} className="cursor-pointer hover:underline">
             <span title="Professor(es)" className="whitespace-nowrap">
               {lesson.schedule.professor_information.map(prof_info => prof_info.acronym).join(', ')}
             </span>

--- a/src/components/planner/schedules/InspectLessonBox.tsx
+++ b/src/components/planner/schedules/InspectLessonBox.tsx
@@ -9,7 +9,11 @@ type Props = {
 
 const InspectLessonBox = ({ lesson, conflict }: Props) => {
   const lessonType = lesson.schedule.lesson_type
-  const professorDescription = lesson.schedule.professor_information.map((prof_info) => prof_info.name).join('\n')
+  const professors = lesson.schedule.professor_information
+    .map((prof_info) => (lesson.schedule.professor_information.length > 1 ? '- ' : '') + prof_info.name)
+    .join('\n')
+  const professorDescription =
+    'Professor' + (lesson.schedule.professor_information.length > 1 ? 'es' : '') + ':\n' + professors
   return (
     <div
       className={classNames(

--- a/src/components/planner/schedules/InspectLessonBox.tsx
+++ b/src/components/planner/schedules/InspectLessonBox.tsx
@@ -9,7 +9,7 @@ type Props = {
 
 const InspectLessonBox = ({ lesson, conflict }: Props) => {
   const lessonType = lesson.schedule.lesson_type
-
+  console.log(lesson.schedule.professors_link)
   return (
     <div
       className={classNames(
@@ -41,9 +41,11 @@ const InspectLessonBox = ({ lesson, conflict }: Props) => {
 
         <div className="flex w-full items-center justify-between gap-2">
           <span title="Sala">{lesson.schedule.location}</span>
-          <span title="Professor(es)" className="whitespace-nowrap">
-            {lesson.schedule.professor_acronyms.join(', ')}
-          </span>
+          <a href={lesson.schedule.professors_link}>
+            <span title="Professor(es)" className="whitespace-nowrap">
+              {lesson.schedule.professor_information.map(prof_info => prof_info.acronym).join(', ')}
+            </span>
+          </a>
         </div>
       </div>
     </div>

--- a/src/components/planner/schedules/LessonBox.tsx
+++ b/src/components/planner/schedules/LessonBox.tsx
@@ -88,7 +88,7 @@ const LessonBox = ({ lesson, active, conflict, conflicts }: Props) => {
               <div className="flex w-full items-center justify-between gap-1">
                 <span title="Sala">{lesson.schedule.location}</span>
                 <span title="Professor(es)" className="truncate">
-                  {lesson.schedule.professor_acronyms.join(', ')}
+                  {lesson.schedule.professor_information.map(prof_info => prof_info.acronym).join(', ')}
                 </span>
               </div>
             </div>
@@ -108,7 +108,7 @@ const LessonBox = ({ lesson, active, conflict, conflicts }: Props) => {
                 <span title="Sala">{lesson.schedule.location}</span>
                 <span title="Turma">{compClassTitle ? compClassTitle : classTitle}</span>
                 <span title="Professor(es)" className="truncate">
-                  {lesson.schedule.professor_acronyms.join(', ')}
+                  {lesson.schedule.professor_information.map(prof_info => prof_info.acronym).join(', ')}
                 </span>
               </div>
             </div>
@@ -118,7 +118,7 @@ const LessonBox = ({ lesson, active, conflict, conflicts }: Props) => {
               <span title="Duração">{timeSpan}</span>
               <span title="Sala">{lesson.schedule.location}</span>
               <span title="Professor(es)" className="truncate">
-                {lesson.schedule.professor_acronyms.join(', ')}
+                {lesson.schedule.professor_information.map(prof_info => prof_info.acronym).join(', ')}
               </span>
             </div>
           )}

--- a/src/components/planner/schedules/LessonBox.tsx
+++ b/src/components/planner/schedules/LessonBox.tsx
@@ -28,6 +28,11 @@ const LessonBox = ({ lesson, active, conflict, conflicts }: Props) => {
   const smLesson = duration < 1
   const lgLesson = duration >= 2
   const mdLesson = !smLesson && !lgLesson
+  const professors = lesson.schedule.professor_information
+    .map((prof_info) => (lesson.schedule.professor_information.length > 1 ? '- ' : '') + prof_info.name)
+    .join('\n')
+  const professorDescription =
+    'Professor' + (lesson.schedule.professor_information.length > 1 ? 'es' : '') + ':\n' + professors
 
   const [inspectShown, setInspectShown] = useState(false)
   const [conflictsShown, setConflictsShown] = useState(false)
@@ -87,8 +92,8 @@ const LessonBox = ({ lesson, active, conflict, conflicts }: Props) => {
               {/* Bottom */}
               <div className="flex w-full items-center justify-between gap-1">
                 <span title="Sala">{lesson.schedule.location}</span>
-                <span title="Professor(es)" className="truncate">
-                  {lesson.schedule.professor_information.map(prof_info => prof_info.acronym).join(', ')}
+                <span title={professorDescription} className="truncate">
+                  {lesson.schedule.professor_information.map((prof_info) => prof_info.acronym).join(', ')}
                 </span>
               </div>
             </div>
@@ -107,8 +112,8 @@ const LessonBox = ({ lesson, active, conflict, conflicts }: Props) => {
               <div className="flex w-full items-center justify-between gap-2">
                 <span title="Sala">{lesson.schedule.location}</span>
                 <span title="Turma">{compClassTitle ? compClassTitle : classTitle}</span>
-                <span title="Professor(es)" className="truncate">
-                  {lesson.schedule.professor_information.map(prof_info => prof_info.acronym).join(', ')}
+                <span title={professorDescription} className="truncate">
+                  {lesson.schedule.professor_information.map((prof_info) => prof_info.acronym).join(', ')}
                 </span>
               </div>
             </div>
@@ -117,8 +122,8 @@ const LessonBox = ({ lesson, active, conflict, conflicts }: Props) => {
             <div className="flex h-full w-full items-center justify-between gap-1 px-1 py-0.5 text-[0.55rem] tracking-tighter xl:text-xxs 2xl:px-1 2xl:py-1 2xl:text-[0.6rem]">
               <span title="Duração">{timeSpan}</span>
               <span title="Sala">{lesson.schedule.location}</span>
-              <span title="Professor(es)" className="truncate">
-                {lesson.schedule.professor_information.map(prof_info => prof_info.acronym).join(', ')}
+              <span title={professorDescription} className="truncate">
+                {lesson.schedule.professor_information.map((prof_info) => prof_info.acronym).join(', ')}
               </span>
             </div>
           )}

--- a/src/components/planner/schedules/ResponsiveLessonBox.tsx
+++ b/src/components/planner/schedules/ResponsiveLessonBox.tsx
@@ -42,7 +42,7 @@ const ResponsiveLessonBox = ({ lesson, conflict }: Props) => {
         <div className="flex w-full items-center justify-between gap-3">
           <span title="Sala">{lesson.schedule.location}</span>
           <span title="Professor(es)" className="whitespace-nowrap">
-            {lesson.schedule.professor_acronyms.join(', ')}
+            {lesson.schedule.professor_information.map(prof_info => prof_info.acronym)}
           </span>
         </div>
       </div>

--- a/src/components/planner/schedules/ResponsiveLessonBox.tsx
+++ b/src/components/planner/schedules/ResponsiveLessonBox.tsx
@@ -42,7 +42,7 @@ const ResponsiveLessonBox = ({ lesson, conflict }: Props) => {
         <div className="flex w-full items-center justify-between gap-3">
           <span title="Sala">{lesson.schedule.location}</span>
           <span title="Professor(es)" className="whitespace-nowrap">
-            {lesson.schedule.professor_information.map(prof_info => prof_info.acronym)}
+            {lesson.schedule.professor_information.map(prof_info => prof_info.acronym).join(', ')}
           </span>
         </div>
       </div>

--- a/src/pages/TimeTableScheduler.tsx
+++ b/src/pages/TimeTableScheduler.tsx
@@ -51,9 +51,8 @@ const TimeTableSchedulerPage = () => {
     schedules.forEach((schedule, idx) => {
       if (schedule.lesson_type !== 'T') {
         schedule.professor_information.forEach(prof_info => {
-          const acronym = prof_info.acronym;
-          if (!teachers.includes(acronym)) {
-            teachers.push(acronym);
+          if (!teachers.some(other => other.acronym === prof_info.acronym)) {
+            teachers.push(prof_info);
           }
         });
       }
@@ -187,9 +186,8 @@ const TimeTableSchedulerPage = () => {
           schedule.forEach((classes) => {
             if (classes.lesson_type !== 'T') {
               classes.professor_information.forEach(prof_info => {
-                const acronym = prof_info.acronym;
-                if (!teachers[idx].includes(acronym)) {
-                  teachers[idx].push(acronym);
+                if (!teachers[idx].some(other => other.acronym === prof_info.acronym)) {
+                  teachers[idx].push(prof_info);
                 }
               });
             }

--- a/src/pages/TimeTableScheduler.tsx
+++ b/src/pages/TimeTableScheduler.tsx
@@ -50,7 +50,8 @@ const TimeTableSchedulerPage = () => {
     let teachers = []
     schedules.forEach((schedule, idx) => {
       if (schedule.lesson_type !== 'T') {
-        schedule.professor_acronyms.forEach(acronym => {
+        schedule.professor_information.forEach(prof_info => {
+          const acronym = prof_info.acronym;
           if (!teachers.includes(acronym)) {
             teachers.push(acronym);
           }
@@ -185,7 +186,8 @@ const TimeTableSchedulerPage = () => {
         schedules.forEach((schedule, idx) => {
           schedule.forEach((classes) => {
             if (classes.lesson_type !== 'T') {
-              classes.professor_acronyms.forEach(acronym => {
+              classes.professor_information.forEach(prof_info => {
+                const acronym = prof_info.acronym;
                 if (!teachers[idx].includes(acronym)) {
                   teachers[idx].push(acronym);
                 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -71,7 +71,8 @@ const timesCollide = (first: CourseSchedule, second: CourseSchedule) => {
 const getScheduleOptionDisplayText = (option: CourseSchedule | null) => {
   // prioritize single class name
   const classTitle = option.class_name !== null ? option.class_name : option.composed_class_name
-  return [classTitle, option.professor_acronyms, convertWeekday(option.day), getLessonBoxTime(option)].join(', ')
+  const professor_acronyms = option.professor_information.map(prof_info => prof_info.acronym)
+  return [classTitle, professor_acronyms, convertWeekday(option.day), getLessonBoxTime(option)].join(', ')
 }
 
 const getLessonBoxTime = (schedule: CourseSchedule) => {
@@ -154,7 +155,8 @@ const getCourseTeachers = (courseOption: CourseOption) => {
   let teachers = []
     courseOption.schedules.forEach((schedule, idx) => {
       if (schedule.lesson_type !== 'T') {
-        schedule.professor_acronyms.forEach(acronym => {
+        schedule.professor_information.forEach(prof_info => {
+          const acronym = prof_info.acronym
           if (!teachers.includes(acronym)) {
             teachers.push(acronym);
           }
@@ -164,7 +166,6 @@ const getCourseTeachers = (courseOption: CourseOption) => {
 
   return teachers
 }
-
 
 export {
   config,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -153,16 +153,15 @@ const getClassTypeClassName = (type: string) => {
 
 const getCourseTeachers = (courseOption: CourseOption) => {
   let teachers = []
-    courseOption.schedules.forEach((schedule, idx) => {
-      if (schedule.lesson_type !== 'T') {
-        schedule.professor_information.forEach(prof_info => {
-          const acronym = prof_info.acronym
-          if (!teachers.includes(acronym)) {
-            teachers.push(acronym);
-          }
-        });
-      }
-    })
+  courseOption.schedules.forEach((schedule, idx) => {
+    if (schedule.lesson_type !== 'T') {
+      schedule.professor_information.forEach(prof_info => {
+        if (!teachers.some(other => other.acronym === prof_info.acronym)) {
+          teachers.push(prof_info);
+        }
+      });
+    }
+  })
 
   return teachers
 }


### PR DESCRIPTION
# What's new?
- When a teacher's acronym is hovered on a slot, a tool-tip will show it's full name (or names in case the slot refers to more than one teacher);
<img width="400" src="https://github.com/NIAEFEUP/tts-revamp-fe/assets/93603699/43989d8b-9dd5-4ee6-b415-e018b4ae1a19">

<br></br>
- When the user opens the slot, the acronym - besides also showing the teacher(s) full name(s) will have an hyperlink to the teacher's sigarra page (or to the sigarra page with all the teachers that teach that class);

[Screencast from 18-08-2023 19:50:06.webm](https://github.com/NIAEFEUP/tts-revamp-fe/assets/93603699/9ea1ac37-d3bd-4b46-ae71-9e5c963234c8)

<br></br>
- Users can now filter which teachers to display in the schedule options;
<img width="400" src="https://github.com/NIAEFEUP/tts-revamp-fe/assets/93603699/a18b54bf-489a-4d5b-945a-34b936510cca">
<img width="400" src="https://github.com/NIAEFEUP/tts-revamp-fe/assets/93603699/7649976f-fc7f-47b7-a21f-0ce580007bf8">

<br></br>
- When the teacher options are hovered, the full name will be displayed instead of the acronym

[Screencast from 18-08-2023 19:57:29.webm](https://github.com/NIAEFEUP/tts-revamp-fe/assets/93603699/f2ab33be-9764-4c25-9f4e-d97cd87d4b57)
