### PR TITLE
Emoji picker's emojis according to browser

### DIFF
--- a/src/components/planner/OptionsController.tsx
+++ b/src/components/planner/OptionsController.tsx
@@ -3,7 +3,7 @@ import { Transition, Menu, Popover } from '@headlessui/react'
 import { CheckIcon, ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/outline'
 import { MultipleOptions } from '../../@types'
 import { ReactSortable, Sortable } from "react-sortablejs"
-import EmojiPicker, { Theme, EmojiStyle, SuggestionMode } from 'emoji-picker-react';
+import EmojiPicker, { Theme, EmojiStyle, SuggestionMode, Emoji } from 'emoji-picker-react';
 import { ThemeContext } from '../../contexts/ThemeContext'
 import {
   PencilAltIcon,
@@ -118,6 +118,17 @@ const OptionsController = ({ multipleOptionsHook }: Props) => {
 
   }
 
+  const getBrowserEmojiStyle = () => {
+    if (window.navigator.userAgent.indexOf("Chrome") !== -1) {
+      return EmojiStyle.GOOGLE;
+    }
+    if (window.navigator.userAgent.indexOf("Safari") !== -1) {
+      return EmojiStyle.APPLE;
+    }
+    return EmojiStyle.NATIVE;
+  };
+  
+
   const option = getOptionById(selected)
 
   return (
@@ -137,7 +148,7 @@ const OptionsController = ({ multipleOptionsHook }: Props) => {
                   previewConfig={{showPreview: false}}
                   theme={enabled ? Theme.DARK : Theme.LIGHT}
                   suggestedEmojisMode={SuggestionMode.RECENT}
-                  emojiStyle={EmojiStyle.NATIVE}
+                  emojiStyle={getBrowserEmojiStyle()}
                   onEmojiClick={(emojiData, event) => {
                     changeOptionIcon(emojiData.emoji);
                     close();

--- a/src/components/planner/OptionsController.tsx
+++ b/src/components/planner/OptionsController.tsx
@@ -31,7 +31,7 @@ const Option = ({item, selectedHook, setOptionIndex, multipleOptionsHook}) => {
           }} 
           className={`box-border p-2 w-10 h-10 aspect-square rounded cursor-pointer border-2 border-transparent hover:border-primary/75 hover:dark:border-primary/50 dark:shadow transition-colors ease-in-out delay-150 ${selected === item.id ? "text-white bg-primary/75 dark:bg-primary/50" : "bg-lightish dark:bg-darkish"}`}
       >
-          {item.icon}
+        <img src={item.icon} className="w-full h-full" />
       </div>
   )
 }
@@ -62,16 +62,16 @@ const OptionsController = ({ multipleOptionsHook }: Props) => {
 
     if(!optionsList) {
       return [
-        { id: 1, icon: "😊", name: "Horário 1" },
-        { id: 2, icon: "🌟", name: "Horário 2" },
-        { id: 3, icon: "🚀", name: "Horário 3" },
-        { id: 4, icon: "📚", name: "Horário 4" },
-        { id: 5, icon: "🎉", name: "Horário 5" },
-        { id: 6, icon: "💻", name: "Horário 6" },
-        { id: 7, icon: "🌈", name: "Horário 7" },
-        { id: 8, icon: "🍀", name: "Horário 8" },
-        { id: 9, icon: "🎓", name: "Horário 9" },
-        { id: 10, icon: "🤖", name: "Horário 10" }
+        { id: 1, icon: "https://cdn.jsdelivr.net/npm/emoji-datasource-apple/img/apple/64/1f60e.png", name: "Horário 1" },
+        { id: 2, icon: "https://cdn.jsdelivr.net/npm/emoji-datasource-apple/img/apple/64/1f929.png", name: "Horário 2" },
+        { id: 3, icon: "https://cdn.jsdelivr.net/npm/emoji-datasource-apple/img/apple/64/1f973.png", name: "Horário 3" },
+        { id: 4, icon: "https://cdn.jsdelivr.net/npm/emoji-datasource-apple/img/apple/64/1f9d0.png", name: "Horário 4" },
+        { id: 5, icon: "https://cdn.jsdelivr.net/npm/emoji-datasource-apple/img/apple/64/1f525.png", name: "Horário 5" },
+        { id: 6, icon: "https://cdn.jsdelivr.net/npm/emoji-datasource-apple/img/apple/64/1f483.png", name: "Horário 6" },
+        { id: 7, icon: "https://cdn.jsdelivr.net/npm/emoji-datasource-apple/img/apple/64/1f483.png", name: "Horário 7" },
+        { id: 8, icon: "https://cdn.jsdelivr.net/npm/emoji-datasource-apple/img/apple/64/1f47b.png", name: "Horário 8" },
+        { id: 9, icon: "https://cdn.jsdelivr.net/npm/emoji-datasource-apple/img/apple/64/1f425.png", name: "Horário 9" },
+        { id: 10, icon: "https://cdn.jsdelivr.net/npm/emoji-datasource-apple/img/apple/64/1fae1.png", name: "Horário 10" }
       ]
     } else {
       return optionsList;
@@ -116,18 +116,7 @@ const OptionsController = ({ multipleOptionsHook }: Props) => {
       return updatedOptionsList;
     });
 
-  }
-
-  const getBrowserEmojiStyle = () => {
-    if (window.navigator.userAgent.indexOf("Chrome") !== -1) {
-      return EmojiStyle.GOOGLE;
-    }
-    if (window.navigator.userAgent.indexOf("Safari") !== -1) {
-      return EmojiStyle.APPLE;
-    }
-    return EmojiStyle.NATIVE;
-  };
-  
+  }  
 
   const option = getOptionById(selected)
 
@@ -137,9 +126,9 @@ const OptionsController = ({ multipleOptionsHook }: Props) => {
         <Popover id="option-header" className="relative">
           <>
             <Popover.Button 
-              className="w-10 h-10 aspect-square rounded bg-lightish dark:bg-darkish text-xl"
+              className="w-10 h-10 p-1 aspect-square rounded hover:bg-lightish hover:dark:bg-darkish text-xl"
               >
-              {option?.icon}
+                <img src={option?.icon} className="w-full h-full" />
             </Popover.Button>
             <Popover.Panel className="absolute translate-y-1 z-10">
               {({ close }) => (
@@ -148,9 +137,9 @@ const OptionsController = ({ multipleOptionsHook }: Props) => {
                   previewConfig={{showPreview: false}}
                   theme={enabled ? Theme.DARK : Theme.LIGHT}
                   suggestedEmojisMode={SuggestionMode.RECENT}
-                  emojiStyle={getBrowserEmojiStyle()}
+                  emojiStyle={EmojiStyle.APPLE}
                   onEmojiClick={(emojiData, event) => {
-                    changeOptionIcon(emojiData.emoji);
+                    changeOptionIcon(emojiData.imageUrl);
                     close();
                   }}
                 />
@@ -169,7 +158,6 @@ const OptionsController = ({ multipleOptionsHook }: Props) => {
               e.target.blur();
           }}
         />
-        {/* <PencilAltIcon id={`${selected}-name-edit-icon`} className="h-5 w-5"></PencilAltIcon> */}
       </div>
       <ReactSortable
         className="flex flex-row justify-start gap-2 overflow-x-auto text-center py-3 m-y-2"


### PR DESCRIPTION
# Problem
This fix intends to display the correct emojis on the emoji picker according to the user's browser.
There also might be a problem on the emojis rendering as you can see in the following images:

| Firefox | Chrome | 
| ---------- | ------------ | 
| ![2024-01-08-02:04:39](https://github.com/NIAEFEUP/tts-revamp-fe/assets/93603699/a9c41428-3875-40b6-9649-07362828d1e4) | ![2024-01-08-02:03:33](https://github.com/NIAEFEUP/tts-revamp-fe/assets/93603699/652b13f9-3331-4387-8909-50fb045df88c) |

If there's someone using other browsers please tell me if the same happened to you. 

# Possible solution
The current emoji picker onClick function looks like this:
```react
onEmojiClick={(emojiData, event) => {
    changeOptionIcon(emojiData.emoji);
    close();
}
```
The emojiData looks like this:
```json
{
  "activeSkinTone": "neutral",
  "emoji": "🫠",
  "imageUrl": "https://cdn.jsdelivr.net/npm/emoji-datasource-apple/img/apple/64/1fae0.png",
  "isCustom": false,
  "names": [
    "melting face"
  ],
  "unified": "1fae0",
  "unifiedWithoutSkinTone": "1fae0"
}
```
So we could probably use the imageUrl instead of the emoji as I think that the problem can be of the browser itself. [Check this post](https://nolanlawson.com/2022/04/08/the-struggle-of-using-native-emoji-on-the-web/)

Closes #167