### PR TITLE
No support Clipboard API readText method alternative

### DIFF
--- a/src/components/planner/Schedule.tsx
+++ b/src/components/planner/Schedule.tsx
@@ -5,7 +5,8 @@ import { Lesson, CourseOption } from '../../@types'
 import { ScheduleGrid, LessonBox, ResponsiveLessonBox } from './schedules'
 import { minHour, maxHour, convertHour, convertWeekdayLong, timesCollide } from '../../utils/utils'
 import { useShowGrid } from '../../hooks'
-import { PrintSchedule, ToggleScheduleGrid } from './schedule'
+import ToggleScheduleGrid from './schedule/ToggleScheduleGrid'
+import PrintSchedule from './schedule/PrintSchedule'
 
 type Props = {
   courseOptions: CourseOption[]

--- a/src/components/planner/sidebar/SelectedOptionController.tsx
+++ b/src/components/planner/sidebar/SelectedOptionController.tsx
@@ -149,7 +149,7 @@ const SelectedOptionController = ({
       </div>
       <div className="flex items-center order-1 gap-1 p-1 sm:order-2 sm:w-1/3 lg:order-1 lg:w-auto xl:order-2">
         <CopyOption majorHook={majorHook} currentOption={currentOption} className="sm:py-0 xl:p-1" />
-        <PasteOption majors={majors} majorHook={majorHook} multipleOptionsHook={multipleOptionsHook} checkCourses={checkCourses} isImportedOptionHook={isImportedOptionHook} className="sm:py-0 xl:p-1" />
+        <PasteOption majors={majors} majorHook={majorHook} multipleOptionsHook={multipleOptionsHook} checkCourses={checkCourses} isImportedOptionHook={isImportedOptionHook} />
         <RandomFill multipleOptionsHook={multipleOptionsHook} className="sm:py-0 xl:p-1" />
       </div>
     </div>


### PR DESCRIPTION
Firefox doesn't support Clipboard API readText method, so this PR adds an alternative way of pasting an option opening a text input to paste the option, which doesn't depend on clipboard API, for browsers not supporting the method.

Demo:
https://github.com/NIAEFEUP/tts-revamp-fe/assets/53405284/b8d0e893-92a0-4a17-a525-d127032da976

